### PR TITLE
fix: #37  nav가 search box를 가리는 오류 해결

### DIFF
--- a/src/sass/components/_search.scss
+++ b/src/sass/components/_search.scss
@@ -14,7 +14,9 @@
 		padding-right: rem(50px);
 		width: rem(600px);
 		height: rem(50px);
-		width: 100%;
+		@include mobile {
+			width: 100%;
+		}
 	}
 
 	&-btn {

--- a/src/sass/components/_search.scss
+++ b/src/sass/components/_search.scss
@@ -1,9 +1,11 @@
 @use './../utils/' as *;
 
 .search {
-	height: rem(50px);
 	&-form {
+		display: inline-block;
+		width: 100%;
 		height: 100%;
+		padding-top: rem(150px);
 	}
 
 	&__input {
@@ -12,9 +14,7 @@
 		padding-right: rem(50px);
 		width: rem(600px);
 		height: rem(50px);
-		@include mobile {
-			width: 100%;
-		}
+		width: 100%;
 	}
 
 	&-btn {
@@ -31,7 +31,11 @@
 		display: flex;
 		justify-content: flex-end;
 		align-items: center;
-		position: relative;
-		top: rem(120px);
+		// position: relative;
+		// margin-top: rem(120px);
+		@include desktop {
+		}
+		@include mobile {
+		}
 	}
 }

--- a/src/sass/pages/_draw.scss
+++ b/src/sass/pages/_draw.scss
@@ -1,8 +1,7 @@
 @use './../utils' as *;
 
 .draw {
-	position: relative;
-	margin-top: rem(120px);
+	margin-top: rem(10px);
 
 	&__title {
 		display: inline-block;


### PR DESCRIPTION
#37 
    - draw box에 margin-top: 10px;
    - search의 container를 rem(50px)로 지정되어 있어서 삭제.
    - &-form inline-block, padding 부여