### PR TITLE
feat: draw 페이지에 main-wrapper 추가, draw-list fieldset에 relatvie 속성 추가

### DIFF
--- a/src/drawlist.html
+++ b/src/drawlist.html
@@ -54,125 +54,127 @@
 
 		<!-- 진행중인 드로우 -->
 		<main>
-			<section class="search">
-				<h2 class="sr-only">상품 검색</h2>
-				<form class="search-form" method="get" action="#">
-					<fieldset>
-						<legend class="sr-only">검색 폼</legend>
-						<label for="search" class="sr-only">상품 검색</label>
-						<input
-							type="search"
-							id="search"
-							class="search__input"
-							name="search"
-							placeholder="상품명 검색"
-							required
-						/>
+			<div class="main-wrapper">
+				<section class="search">
+					<h2 class="sr-only">상품 검색</h2>
+					<form class="search-form" method="get" action="#">
+						<fieldset>
+							<legend class="sr-only">검색 폼</legend>
+							<label for="search" class="sr-only">상품 검색</label>
+							<input
+								type="search"
+								id="search"
+								class="search__input"
+								name="search"
+								placeholder="상품명 검색"
+								required
+							/>
 
-						<button type="submit" class="search-btn"></button>
-					</fieldset>
-				</form>
-			</section>
+							<button type="submit" class="search-btn"></button>
+						</fieldset>
+					</form>
+				</section>
 
-			<section class="draw">
-				<h2 class="draw__title">진행중인 드로우 상품 목록</h2>
-				<button
-					class="draw__button is-active"
-					aria-pressed="true"
-					aria-label="더보기"
-					type="button"
-				>
-					모아보기
+				<section class="draw">
+					<h2 class="draw__title">진행중인 드로우 상품 목록</h2>
+					<button
+						class="draw__button is-active"
+						aria-pressed="true"
+						aria-label="더보기"
+						type="button"
+					>
+						모아보기
+					</button>
+					<ul class="draw__list">
+						<li>
+							<figure class="draw__figure">
+								<a class="draw__link" href="#">
+									<img
+										class="draw__img"
+										src="./assets/images/shoes.jpg"
+										alt="nike shoes"
+									/>
+								</a>
+								<figcaption>
+									<span>덩크 로우 블랙화이트1</span>
+									<span>10000</span>
+								</figcaption>
+							</figure>
+							<div>
+								<span> 상세 설명 </span>
+								<span> 지점 </span>
+							</div>
+						</li>
+						<li>
+							<figure class="draw__figure">
+								<a class="draw__link" href="#">
+									<img
+										class="draw__img"
+										src="./assets/images/shoes.jpg"
+										alt="nike shoes"
+									/>
+								</a>
+								<figcaption>
+									<span>덩크 로우 블랙화이트2</span>
+									<span>10000</span>
+								</figcaption>
+							</figure>
+							<div>
+								<span> 상세 설명 </span>
+								<span> 지점 </span>
+							</div>
+						</li>
+						<li>
+							<figure class="draw__figure">
+								<a class="draw__link" href="#">
+									<img src="./assets/images/shoes.jpg" alt="nike shoes" />
+								</a>
+								<figcaption>
+									<span>덩크 로우 블랙화이트3</span>
+									<span>10000</span>
+								</figcaption>
+							</figure>
+							<div>
+								<span> 상세 설명 </span>
+								<span> 지점 </span>
+							</div>
+						</li>
+						<li>
+							<figure class="draw__figure">
+								<a class="draw__link" href="#">
+									<img src="./assets/images/shoes.jpg" alt="nike shoes" />
+								</a>
+								<figcaption>
+									<span>덩크 로우 블랙화이트4</span>
+									<span>10000</span>
+								</figcaption>
+							</figure>
+							<div>
+								<span> 상세 설명 </span>
+								<span> 지점 </span>
+							</div>
+						</li>
+						<li>
+							<figure class="draw__figure">
+								<a class="draw__link" href="#">
+									<img src="./assets/images/shoes.jpg" alt="nike shoes" />
+								</a>
+								<figcaption>
+									<span>덩크 로우 블랙화이트5</span>
+									<span>10000</span>
+								</figcaption>
+							</figure>
+							<div>
+								<span> 상세 설명 </span>
+								<span> 지점 </span>
+							</div>
+						</li>
+					</ul>
+				</section>
+				<button class="button-top" aria-label="맨위로이동" type="button">
+					&uarr;
 				</button>
-				<ul class="draw__list">
-					<li>
-						<figure class="draw__figure">
-							<a class="draw__link" href="#">
-								<img
-									class="draw__img"
-									src="./assets/images/shoes.jpg"
-									alt="nike shoes"
-								/>
-							</a>
-							<figcaption>
-								<span>덩크 로우 블랙화이트1</span>
-								<span>10000</span>
-							</figcaption>
-						</figure>
-						<div>
-							<span> 상세 설명 </span>
-							<span> 지점 </span>
-						</div>
-					</li>
-					<li>
-						<figure class="draw__figure">
-							<a class="draw__link" href="#">
-								<img
-									class="draw__img"
-									src="./assets/images/shoes.jpg"
-									alt="nike shoes"
-								/>
-							</a>
-							<figcaption>
-								<span>덩크 로우 블랙화이트2</span>
-								<span>10000</span>
-							</figcaption>
-						</figure>
-						<div>
-							<span> 상세 설명 </span>
-							<span> 지점 </span>
-						</div>
-					</li>
-					<li>
-						<figure class="draw__figure">
-							<a class="draw__link" href="#">
-								<img src="./assets/images/shoes.jpg" alt="nike shoes" />
-							</a>
-							<figcaption>
-								<span>덩크 로우 블랙화이트3</span>
-								<span>10000</span>
-							</figcaption>
-						</figure>
-						<div>
-							<span> 상세 설명 </span>
-							<span> 지점 </span>
-						</div>
-					</li>
-					<li>
-						<figure class="draw__figure">
-							<a class="draw__link" href="#">
-								<img src="./assets/images/shoes.jpg" alt="nike shoes" />
-							</a>
-							<figcaption>
-								<span>덩크 로우 블랙화이트4</span>
-								<span>10000</span>
-							</figcaption>
-						</figure>
-						<div>
-							<span> 상세 설명 </span>
-							<span> 지점 </span>
-						</div>
-					</li>
-					<li>
-						<figure class="draw__figure">
-							<a class="draw__link" href="#">
-								<img src="./assets/images/shoes.jpg" alt="nike shoes" />
-							</a>
-							<figcaption>
-								<span>덩크 로우 블랙화이트5</span>
-								<span>10000</span>
-							</figcaption>
-						</figure>
-						<div>
-							<span> 상세 설명 </span>
-							<span> 지점 </span>
-						</div>
-					</li>
-				</ul>
-			</section>
-			<button class="button-top" aria-label="맨위로이동" type="button">
-				&uarr;
-			</button>
+			</div>
 		</main>
 
 		<!-- 푸터 -->

--- a/src/sass/components/_search.scss
+++ b/src/sass/components/_search.scss
@@ -16,9 +16,14 @@
 		height: rem(50px);
 		@include border;
 		border-radius: rem(5px);
+		transition: border 0.3s ease-in-out;
 		@include mobile {
 			width: 100%;
 		}
+	}
+
+	&__input:hover {
+		@include border($px: 3px, $color: black);
 	}
 	&__input:focus {
 		@include border($px: 3px, $color: black);
@@ -35,6 +40,7 @@
 	}
 
 	fieldset {
+		position: relative;
 		display: flex;
 		justify-content: flex-end;
 		align-items: center;

--- a/src/sass/components/_search.scss
+++ b/src/sass/components/_search.scss
@@ -14,9 +14,14 @@
 		padding-right: rem(50px);
 		width: rem(600px);
 		height: rem(50px);
+		@include border;
+		border-radius: rem(5px);
 		@include mobile {
 			width: 100%;
 		}
+	}
+	&__input:focus {
+		@include border($px: 3px, $color: black);
 	}
 
 	&-btn {
@@ -26,7 +31,7 @@
 		height: rem(20px);
 		width: rem(20px);
 		position: absolute;
-		right: 2%;
+		right: rem(10px);
 	}
 
 	fieldset {

--- a/src/sass/pages/_draw.scss
+++ b/src/sass/pages/_draw.scss
@@ -1,8 +1,6 @@
 @use './../utils' as *;
 
 .draw {
-	margin-top: rem(10px);
-
 	&__title {
 		display: inline-block;
 		width: 100%;


### PR DESCRIPTION
- 검색창의 돋보기가 main-wrapper를 추가했을 때, 벗어나는 현상. 부모 컨테이너에 relative 속성이 없어서 레이아웃 밖으로 벗어나는 현상 해결
- 검색창의 UI 디자인